### PR TITLE
Added clear_queue function to QueuedClient

### DIFF
--- a/riemann_client/client.py
+++ b/riemann_client/client.py
@@ -93,3 +93,6 @@ class QueuedClient(Client):
     def send_event(self, event):
         self.queue.events.add().MergeFrom(event)
         return event
+
+    def clear_queue(self):
+        self.queue = riemann_client.riemann_pb2.Msg()

--- a/riemann_client/tests/test_riemann_queued_client.py
+++ b/riemann_client/tests/test_riemann_queued_client.py
@@ -65,3 +65,8 @@ def test_deciqueue_output(queued_client, large_queue):
 def test_deciqueue_flush(queued_client, large_queue):
     queued_client.flush()
     assert len(queued_client.queue.events) == 0
+
+
+def test_clear_queue(queued_client, using_simple_queue):
+    queued_client.clear_queue()
+    assert len(queued_client.queue.events) == 0


### PR DESCRIPTION
I would like this function for the following case: When my riemann server is down and my queue is getting really big, I want to clear it.
