### PR TITLE
added send_events function to clients

### DIFF
--- a/riemann_client/client.py
+++ b/riemann_client/client.py
@@ -45,6 +45,13 @@ class Client(object):
         message.events.add().MergeFrom(event)
         return self.transport.send(message)
 
+    def send_events(self, events):
+        """Wraps events in a message and sends them to Riemann"""
+        message = riemann_client.riemann_pb2.Msg()
+        for event in events:
+            message.events.add().MergeFrom(event)
+        return self.transport.send(message)
+
     def event(self, **data):
         """Sends an event"""
         return self.send_event(self.create_event(data))
@@ -93,3 +100,7 @@ class QueuedClient(Client):
     def send_event(self, event):
         self.queue.events.add().MergeFrom(event)
         return event
+
+    def send_events(self, events):
+        for event in events:
+            self.send_event(event)

--- a/riemann_client/tests/test_riemann_queued_client.py
+++ b/riemann_client/tests/test_riemann_queued_client.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import py.test
+import uuid
 
 import riemann_client.client
 import riemann_client.riemann_pb2
@@ -35,6 +36,21 @@ def large_queue(queued_client):
     return items
 
 
+@py.test.fixture
+def unique():
+    return str(uuid.uuid4())
+
+
+@py.test.fixture
+def event(unique):
+    return riemann_client.client.Client.create_event({
+        'host': 'test.example.com',
+        'tags': [unique],
+        'attributes': {
+            unique: unique
+        }
+    })
+
 def test_simple_queue_event(queued_client, using_simple_queue):
     assert queued_client.queue.events[0].service == 'test'
 
@@ -65,3 +81,9 @@ def test_deciqueue_output(queued_client, large_queue):
 def test_deciqueue_flush(queued_client, large_queue):
     queued_client.flush()
     assert len(queued_client.queue.events) == 0
+
+
+def test_send_events(queued_client, event):
+    events = [event for i in range(0, 5)]
+    queued_client.send_events(events)
+    assert len(queued_client.queue.events) == 5


### PR DESCRIPTION
Client:
There are cases where I want to manage my queue myself (and not use QueuedClient) so a send_events function is practical to send them all in one message.

QueuedClient:
send_events just makes it easier to add an bunch of messages in the queue.

Update: Feel free to choose between this and #14.
