### PR TITLE
python-click 5 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     ],
 
     install_requires=[
-        'click>=3.1,<4.0',
+        'click>=3.1,<6.0',
         protobuf
     ],
 

--- a/tests/test_riemann_command.py
+++ b/tests/test_riemann_command.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 
 import re
 import socket
@@ -9,7 +9,7 @@ import riemann_client.command
 
 
 def run_cli(args):
-    args = ['-T', 'none'] + list(args)
+    args = [u'-T', u'none'] + list(args)
     runner = click.testing.CliRunner()
     result = runner.invoke(riemann_client.command.main, args)
     assert result.exit_code == 0
@@ -17,7 +17,7 @@ def run_cli(args):
 
 
 def strip(string):
-    return re.sub('\s+', '', string)
+    return re.sub(u'\s+', u'', string)
 
 
 def assert_output_eq(args, expected):
@@ -25,10 +25,10 @@ def assert_output_eq(args, expected):
 
 
 def test_send_empty_message():
-    assert_output_eq(['send'], '{"host": "%s"}' % socket.gethostname())
+    assert_output_eq([u'send'], u'{"host": "%s"}' % socket.gethostname())
 
 
-POPULATED_MESSAGE = """{
+POPULATED_MESSAGE = u"""{
   "attributes": {
     "key": "value"
   },
@@ -48,31 +48,31 @@ POPULATED_MESSAGE = """{
 
 def test_send():
     assert_output_eq([
-        'send',
-        '--attribute', 'key=value',
-        '--description', 'description',
-        '--metric_f', '11.1',
-        '--service', 'service',
-        '--state', 'state',
-        '--tag', 'tag',
-        '--time', '1408030991',
-        '--ttl', '120'
+        u'send',
+        u'--attribute', u'key=value',
+        u'--description', u'description',
+        u'--metric_f', u'11.1',
+        u'--service', u'service',
+        u'--state', u'state',
+        u'--tag', u'tag',
+        u'--time', u'1408030991',
+        u'--ttl', u'120'
     ], POPULATED_MESSAGE)
 
 
 def test_send_short():
     assert_output_eq([
-        'send',
-        '-a', 'key=value',
-        '-d', 'description',
-        '-m', '11.1',
-        '-s', 'service',
-        '-S', 'state',
-        '-t', 'tag',
-        '-T', '1408030991',
-        '-l', '120'
+        u'send',
+        u'-a', u'key=value',
+        u'-d', u'description',
+        u'-m', u'11.1',
+        u'-s', u'service',
+        u'-S', u'state',
+        u'-t', u'tag',
+        u'-T', u'1408030991',
+        u'-l', u'120'
     ], POPULATED_MESSAGE)
 
 
 def test_query():
-    assert_output_eq(['query', 'true'], '[]')
+    assert_output_eq([u'query', u'true'], u'[]')


### PR DESCRIPTION
python-click 5 raised an error during tests.

See: http://click.pocoo.org/5/python3/#unicode-literals

This is the only files that we are required to change, as unicode_literals is not used in the rest of the program.