### PR TITLE
Relative imports + __main__ module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@ Usage
 
 As a command line tool::
 
-    riemann-client [--host HOST] [--port PORT] send [-s SERVICE] [-S STATE] [-m METRIC] [...]
-    riemann-client [--host HOST] [--port PORT] query QUERY
+  riemann-client [--host HOST] [--port PORT] send [-s SERVICE] [-S STATE] [-m METRIC] [...]
+  riemann-client [--host HOST] [--port PORT] query QUERY
 
 The host and port used by the command line tool can also be set with the
 ``RIEMANN_HOST`` and ``RIEMANN_PORT`` environment variables. By default,
@@ -37,22 +37,22 @@ The host and port used by the command line tool can also be set with the
 
 As a library::
 
-    import riemann_client.client
+  import riemann_client.client
 
-    with riemann_client.client.Client() as client:
-        client.event(service="riemann-client", state="awesome")
-        client.query("service = 'riemann-client'")
+  with riemann_client.client.Client() as client:
+      client.event(service="riemann-client", state="awesome")
+      client.query("service = 'riemann-client'")
 
 A more detailed example, using both a non-default transport and a queued
 client::
 
-    from riemann_client.transport import TCPTransport
-    from riemann_client.client import QueuedClient
+  from riemann_client.transport import TCPTransport
+  from riemann_client.client import QueuedClient
 
-    with QueuedClient(TCPTransport("localhost", 5555)) as client:
-        client.event(service="one", metric_f=0.1)
-        client.event(service="two", metric_f=0.2)
-        client.flush()
+  with QueuedClient(TCPTransport("localhost", 5555)) as client:
+      client.event(service="one", metric_f=0.1)
+      client.event(service="two", metric_f=0.2)
+      client.flush()
 
 The ``QueuedClient`` class modifies the ``event()`` method to add events to a
 queue instead of immediately sending them, and adds the ``flush()`` method to
@@ -64,7 +64,7 @@ Installation
 ``riemann-client`` requires Python 2.6 or above, and can be installed with
 ``pip install riemann-client``. It will use Google's `protobuf`_ library when
 running under Python 2, and `GreatFruitOmsk`_'s `protobuf-py3`_ fork when
-running under Python 3. Python 3 support is experimental and is likley to use
+running under Python 3. Python 3 support is experimental and is likely to use
 Google's `protobuf` once it supports Python 3 fully.
 
 .. _protobuf: https://pypi.python.org/pypi/protobuf
@@ -79,7 +79,7 @@ Requirements
 * `protobuf-py3`_ (when using Python 3)
 
 Testing (Linux/OSX)
--------
+-------------------
 
 Testing is done with `tox`_::
 

--- a/riemann_client/__init__.py
+++ b/riemann_client/__init__.py
@@ -15,5 +15,5 @@ try:
 except ImportError:
     pass
 
-__version__ = '6.1.3'
+__version__ = '6.4.0'
 __author__ = 'Sam Clements <sam.clements@datasift.com>'

--- a/riemann_client/__init__.py
+++ b/riemann_client/__init__.py
@@ -1,4 +1,19 @@
 """A Python Riemann client and command line tool"""
 
+from .client import (
+    Client, QueuedClient  # noqa
+)
+
+from .transport import (
+    RiemannError, SocketTransport, UDPTransport,  # noqa
+    TCPTransport, TLSTransport, BlankTransport,   # noqa
+)
+
+
+try:
+    from .client import AutoFlushingQueuedClient  # noqa
+except ImportError:
+    pass
+
 __version__ = '6.1.3'
 __author__ = 'Sam Clements <sam.clements@datasift.com>'

--- a/riemann_client/__main__.py
+++ b/riemann_client/__main__.py
@@ -1,0 +1,9 @@
+"""Riemann command line client"""
+
+from __future__ import absolute_import
+
+from . import command
+
+
+if __name__ == '__main__':
+    command.main()

--- a/riemann_client/client.py
+++ b/riemann_client/client.py
@@ -24,8 +24,8 @@ except ImportError:
     Timer = None
 import time
 
-import riemann_client.riemann_pb2
-import riemann_client.transport
+from . import riemann_pb2
+from .transport import UDPTransport, TCPTransport
 
 
 logger = logging.getLogger(__name__)
@@ -65,7 +65,7 @@ class Client(object):
 
     def __init__(self, transport=None):
         if transport is None:
-            transport = riemann_client.transport.TCPTransport()
+            transport = TCPTransport()
         self.transport = transport
 
     def __enter__(self):
@@ -82,7 +82,7 @@ class Client(object):
         :param dict data: The attributes to be set on the event
         :returns: A protocol buffer ``Event`` object
         """
-        event = riemann_client.riemann_pb2.Event()
+        event = riemann_pb2.Event()
         event.host = socket.gethostname()
         event.tags.extend(data.pop('tags', []))
 
@@ -101,7 +101,7 @@ class Client(object):
         :param events: A list or iterable of ``Event`` objects
         :returns: The response message from Riemann
         """
-        message = riemann_client.riemann_pb2.Msg()
+        message = riemann_pb2.Msg()
         for event in events:
             message.events.add().MergeFrom(event)
         return self.transport.send(message)
@@ -161,7 +161,7 @@ class Client(object):
 
         :returns: The response message from Riemann
         """
-        message = riemann_client.riemann_pb2.Msg()
+        message = riemann_pb2.Msg()
         message.query.string = query
         return self.transport.send(message)
 
@@ -173,7 +173,7 @@ class Client(object):
         :returns: A list of event dictionaries taken from the response
         :raises Exception: if used with a :py:class:`.UDPTransport`
         """
-        if isinstance(self.transport, riemann_client.transport.UDPTransport):
+        if isinstance(self.transport, UDPTransport):
             raise Exception('Cannot query the Riemann server over UDP')
         response = self.send_query(query)
         return [self.create_dict(e) for e in response.events]
@@ -219,7 +219,7 @@ class QueuedClient(Client):
 
     def clear_queue(self):
         """Resets the message/queue to a blank :py:class:`.Msg` object"""
-        self.queue = riemann_client.riemann_pb2.Msg()
+        self.queue = riemann_pb2.Msg()
 
 
 if RLock and Timer:  # noqa
@@ -364,3 +364,6 @@ if RLock and Timer:  # noqa
             a :py:meth:`.flush` event will reactviate the timer
             """
             self.timer.cancel()
+
+
+__all__ = 'Client', 'QueuedClient', 'AutoFlushingQueuedClient'

--- a/riemann_client/riemann_pb2.py
+++ b/riemann_client/riemann_pb2.py
@@ -5,6 +5,6 @@ import sys
 __all__ = ['Event', 'Msg', 'Query', 'Attribute']
 
 if sys.version_info >= (3,):
-    from riemann_client.riemann_pb2_py3 import (Event, Msg, Query, Attribute)
+    from .riemann_pb2_py3 import (Event, Msg, Query, Attribute)
 else:
-    from riemann_client.riemann_pb2_py2 import (Event, Msg, Query, Attribute)
+    from .riemann_pb2_py2 import (Event, Msg, Query, Attribute)

--- a/riemann_client/transport.py
+++ b/riemann_client/transport.py
@@ -9,7 +9,7 @@ import socket
 import ssl
 import struct
 
-import riemann_client.riemann_pb2
+from . import riemann_pb2
 
 
 # Default arguments
@@ -138,7 +138,7 @@ class TCPTransport(SocketTransport):
         self.socket.sendall(struct.pack('!I', len(message)) + message)
 
         length = struct.unpack('!I', self.socket.recv(4))[0]
-        response = riemann_client.riemann_pb2.Msg()
+        response = riemann_pb2.Msg()
         response.ParseFromString(socket_recvall(self.socket, length))
 
         if not response.ok:
@@ -190,7 +190,7 @@ class BlankTransport(Transport):
         """
         for event in message.events:
             self.events.append(event)
-        reply = riemann_client.riemann_pb2.Msg()
+        reply = riemann_pb2.Msg()
         reply.ok = True
         return reply
 
@@ -200,3 +200,9 @@ class BlankTransport(Transport):
 
     def __len__(self):
         return len(self.events)
+
+
+__all__ = (
+    'RiemannError', 'SocketTransport', 'UDPTransport',
+    'TCPTransport', 'TLSTransport', 'BlankTransport',
+)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ else:
 
 setuptools.setup(
     name='riemann-client',
-    version='6.3.0',
+    version='6.4.0',
 
     author="Sam Clements",
     author_email="sam.clements@datasift.com",


### PR DESCRIPTION
Hello @borntyping,

First of all, thank you for putting all the effort into this project - it's the best Riemann Python client out there. 

This PR includes several small fixes, that make it easier for me and my colleagues to use the project (plus an unrelated fix to the readme):
- Using relative imports lets the user decide how the module is named (comes  handy when you're vendoring the package).
- Adding all _public_ classes to **init** takes away some of the repetitiveness in the imports (e.g. `from riemann_client.client import Client`). If need be, this also lets you refactor the package structure more easily, as it all appears flat to the caller.

``` python
from riemann import Client as RiemannClient

with RiemannClient() as client:
    event = {...}
    client.send(**event)
```
- Make the command-line program executable with `python -m riemann_client`. This is also necessary for riemann_client to work as a zipapp.

Kind regards,
Georgi
